### PR TITLE
ops(ci): add add-latest-tag build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,25 @@ jobs:
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker build -t lifely/bisc-backend:$CIRCLE_SHA1 .
           docker push lifely/bisc-backend:$CIRCLE_SHA1
+  
+  add-latest-tag:
+    docker:
+      - image: docker:git
+
+    working_directory: ~/app
+
+    steps:
+      - checkout
+      - setup_remote_docker
+
+      - run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
+          docker pull lifely/bisc-backend:$CIRCLE_SHA1
+          docker pull lifely/bisc-frontend:$CIRCLE_SHA1
+          docekr tag lifely/bisc-backend:$CIRCLE_SHA1 lifely/bisc-backend:latest
+          docekr tag lifely/bisc-frontend:$CIRCLE_SHA1 lifely/bisc-frontend:latest
+          docker push lifely/bisc-backend:latest
+          docker push lifely/bisc-frontend:latest
 
 workflows:
   version: 2
@@ -78,6 +97,16 @@ workflows:
               ignore:
                 - /feature\/.*/
                 - /fix\/.*/
+      - add-latest-tag:
+          context: docker-hub-auth
+          requires:
+            - build-and-push-frontend
+            - build-and-push-backend
+          filters:
+            branches:
+              only:
+                - /ops\/.*/
+                - develop
   nightly-develop:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,8 @@ jobs:
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker pull lifely/bisc-backend:$CIRCLE_SHA1
           docker pull lifely/bisc-frontend:$CIRCLE_SHA1
-          docekr tag lifely/bisc-backend:$CIRCLE_SHA1 lifely/bisc-backend:latest
-          docekr tag lifely/bisc-frontend:$CIRCLE_SHA1 lifely/bisc-frontend:latest
+          docker tag lifely/bisc-backend:$CIRCLE_SHA1 lifely/bisc-backend:latest
+          docker tag lifely/bisc-frontend:$CIRCLE_SHA1 lifely/bisc-frontend:latest
           docker push lifely/bisc-backend:latest
           docker push lifely/bisc-frontend:latest
 


### PR DESCRIPTION
We need a `latest` Docker tag to make it easier to deploy to a test environment. With this change we always link the `latest` tag to the most recent develop build