### PR TITLE
feat(taalhuisEmployee): change employeeId parameter to userId

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -167,7 +167,7 @@ export type QueryTaalhuisEmployeesArgs = {
 }
 
 export type QueryTaalhuisEmployeeArgs = {
-    employeeId: Scalars['String']
+    userId: Scalars['String']
 }
 
 export type QueryAanbiederArgs = {

--- a/server/src/Taalhuis/TaalhuisEmployeeResolver.ts
+++ b/server/src/Taalhuis/TaalhuisEmployeeResolver.ts
@@ -48,7 +48,7 @@ class TaalhuisEmployeesArgs {
 @ArgsType()
 class TaalhuisEmployeeArgs {
     @Field()
-    public employeeId!: string
+    public userId!: string
 }
 
 @Resolver(() => TaalhuisEmployeeType)
@@ -87,7 +87,7 @@ export class TaalhuisEmployeeResolver {
         @Args() args: TaalhuisEmployeeArgs
     ): Promise<TaalhuisEmployeeType> {
         // TODO: Authorization checks (user type, user role)
-        return this.taalhuisEmployeeService.findById(args.employeeId)
+        return this.taalhuisEmployeeService.findByUserId(args.userId)
     }
 
     @Mutation(() => TaalhuisEmployeeType)

--- a/server/src/Taalhuis/TaalhuisEmployeeService.ts
+++ b/server/src/Taalhuis/TaalhuisEmployeeService.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common'
+import { assert } from 'console'
 import { assertNotNil } from 'src/AssertNotNil'
 import { PersonRepository } from 'src/CommonGroundAPI/cc/PersonRepository'
 import { EmployeeRepository } from 'src/CommonGroundAPI/mrc/EmployeeRepository'
@@ -41,6 +42,19 @@ export class TaalhuisEmployeeService {
         )
 
         return taalhuisEmployees
+    }
+
+    public async findByUserId(userId: string): Promise<TaalhuisEmployeeType> {
+        const user = await this.userRepository.findById(userId)
+        assertNotNil(user, `User not found for ID ${userId}`)
+
+        const personId = user.person
+        assertNotNil(personId, `PersonId not set for User ${userId}`)
+
+        const employee = await this.employeeRepository.findByPersonId(personId)
+        assertNotNil(employee, `Employee not found for Person ${personId}`)
+
+        return this.findById(employee.id)
     }
 
     public async findById(employeeId: string): Promise<TaalhuisEmployeeType> {


### PR DESCRIPTION
We only expose userId in the current queries and we never expose employeeId, so I now changed the `taalhuisEmployee` query parameter to `userId`