### PR TITLE
feat(memo): add integration with Memo API

### DIFF
--- a/server/codegen.yml
+++ b/server/codegen.yml
@@ -133,6 +133,28 @@ generates:
                 DateTime: Date
                 Date: Date
                 JSON: Record<string, unknown>
+    src/generated/memo-introspection-result.json:
+        schema:
+            - https://taalhuizen-bisc.commonground.nu/api/v1/memo/graphql:
+                  headers:
+                      Authorization: ${API_KEY}
+        plugins:
+            - fragment-matcher
+    src/generated/memo-graphql.ts:
+        schema:
+            - https://taalhuizen-bisc.commonground.nu/api/v1/memo/graphql:
+                  headers:
+                      Authorization: ${API_KEY}
+        plugins:
+            - 'typescript'
+            - 'typescript-operations'
+            - 'typescript-graphql-request'
+        documents: ./src/queries/memo/*.graphql
+        config:
+            scalars:
+                DateTime: Date
+                Date: Date
+                JSON: Record<string, unknown>
 
 hooks:
     afterAllFileWrite:

--- a/server/src/CommonGroundAPI/CommonGroundAPIModule.ts
+++ b/server/src/CommonGroundAPI/CommonGroundAPIModule.ts
@@ -12,6 +12,7 @@ import { ParticipantRepository } from './edu/ParticipantRepository'
 import { ProgramRepository } from './edu/ProgramRepository'
 import { GroupRepository } from './uc/GroupRepository'
 import { SourceOrganizationRepository } from './wrc/SourceOrganizationRepository'
+import { MemoRepository } from './memo/MemoRepository'
 
 @Module({
     providers: [
@@ -28,6 +29,7 @@ import { SourceOrganizationRepository } from './wrc/SourceOrganizationRepository
         OrganizationRepository,
         PersonRepository,
         GroupRepository,
+        MemoRepository,
     ],
     exports: [
         CommonGroundAPIService,
@@ -43,6 +45,7 @@ import { SourceOrganizationRepository } from './wrc/SourceOrganizationRepository
         OrganizationRepository,
         PersonRepository,
         GroupRepository,
+        MemoRepository,
     ],
     imports: [],
 })

--- a/server/src/CommonGroundAPI/CommonGroundAPIsEnum.ts
+++ b/server/src/CommonGroundAPI/CommonGroundAPIsEnum.ts
@@ -4,4 +4,5 @@ export enum CommonGroundAPIs {
     MRC = 'https://taalhuizen-bisc.commonground.nu/api/v1/mrc',
     UC = 'https://taalhuizen-bisc.commonground.nu/api/v1/uc',
     WRC = 'https://taalhuizen-bisc.commonground.nu/api/v1/wrc',
+    MEMO = 'https://taalhuizen-bisc.commonground.nu/api/v1/memo',
 }

--- a/server/src/CommonGroundAPI/MEMORepository.ts
+++ b/server/src/CommonGroundAPI/MEMORepository.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { GraphQLClient } from 'graphql-request'
+import { BaseRepository } from 'src/BaseRepository'
+import { Config } from 'src/config'
+import { getSdk, Sdk as MEMOSdk } from 'src/generated/memo-graphql'
+import { CommonGroundAPIs } from './CommonGroundAPIsEnum'
+
+@Injectable()
+export class MEMORepository extends BaseRepository {
+    protected sdk: MEMOSdk
+    protected commonGroundAPI = CommonGroundAPIs.MEMO
+
+    public constructor(private configService: ConfigService<Config>) {
+        super()
+
+        const client = new GraphQLClient(`${this.commonGroundAPI}/graphql`, {
+            headers: {
+                authorization: this.configService.get('API_KEY') || '',
+            },
+        })
+        this.sdk = getSdk(client)
+    }
+}

--- a/server/src/CommonGroundAPI/memo/MemoRepository.ts
+++ b/server/src/CommonGroundAPI/memo/MemoRepository.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common'
+import { assertNotNil } from 'src/AssertNotNil'
+import { Memo } from 'src/generated/memo-graphql'
+import { MEMORepository } from '../MEMORepository'
+
+interface CreateMemoInput {
+    topic: string
+    author: string
+    name: string
+    description: string
+}
+
+type MemoEntity = Pick<Memo, 'id' | 'name' | 'description' | 'author' | 'topic'>
+
+@Injectable()
+export class MemoRepository extends MEMORepository {
+    public async createMemo(input: CreateMemoInput) {
+        const result = await this.sdk.createMemo({
+            input,
+        })
+
+        const memoObject = result?.createMemo?.memo
+        assertNotNil(memoObject, `Failed to create memo`)
+
+        memoObject.id = this.makeURLfromID(memoObject.id)
+
+        return this.returnNonNullable(memoObject)
+    }
+
+    public async findByTopicAndAuthor(topic: string, author: string) {
+        const result = await this.sdk.findMemosByTopicAndAuthor({ topic, author })
+
+        const memoEdges = result.memos?.edges
+
+        if (!memoEdges) {
+            return []
+        }
+
+        const memoEntities: MemoEntity[] = memoEdges.map(memoEdge => {
+            const memoNode = memoEdge?.node
+            assertNotNil(memoNode)
+
+            const id = memoNode.id
+            assertNotNil(id)
+
+            const name = memoNode.name
+            assertNotNil(name)
+
+            const description = memoNode.description
+            assertNotNil(description)
+
+            const author = memoNode.author
+            assertNotNil(author)
+
+            const topic = memoNode.topic
+            assertNotNil(topic)
+
+            return {
+                id: this.makeURLfromID(id),
+                name,
+                description,
+                author,
+                topic,
+            }
+        })
+
+        return memoEntities
+    }
+}

--- a/server/src/generated/memo-graphql.ts
+++ b/server/src/generated/memo-graphql.ts
@@ -1,0 +1,615 @@
+import { GraphQLClient } from 'graphql-request'
+import * as Dom from 'graphql-request/dist/types.dom'
+import { print } from 'graphql'
+import gql from 'graphql-tag'
+export type Maybe<T> = T | null
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> }
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> }
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+    ID: string
+    String: string
+    Boolean: boolean
+    Int: number
+    Float: number
+    /** The `Iterable` scalar type represents an array or a Traversable with any kind of data. */
+    Iterable: any
+}
+
+export type Query = {
+    __typename?: 'Query'
+    node?: Maybe<Node>
+    memo?: Maybe<Memo>
+    memos?: Maybe<MemoConnection>
+    auditTrail?: Maybe<AuditTrail>
+    auditTrails?: Maybe<AuditTrailConnection>
+    changeLog?: Maybe<ChangeLog>
+    changeLogs?: Maybe<ChangeLogConnection>
+}
+
+export type QueryNodeArgs = {
+    id: Scalars['ID']
+}
+
+export type QueryMemoArgs = {
+    id: Scalars['ID']
+}
+
+export type QueryMemosArgs = {
+    first?: Maybe<Scalars['Int']>
+    last?: Maybe<Scalars['Int']>
+    before?: Maybe<Scalars['String']>
+    after?: Maybe<Scalars['String']>
+    order?: Maybe<MemoFilter_Order>
+    dateCreated?: Maybe<Scalars['String']>
+    dateModified?: Maybe<Scalars['String']>
+    id?: Maybe<Scalars['String']>
+    id_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    author?: Maybe<Scalars['String']>
+    author_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    name?: Maybe<Scalars['String']>
+    name_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    topic?: Maybe<Scalars['String']>
+    topic_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    description?: Maybe<Scalars['String']>
+    description_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    dateCreated_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    dateModified_list?: Maybe<Array<Maybe<Scalars['String']>>>
+}
+
+export type QueryAuditTrailArgs = {
+    id: Scalars['ID']
+}
+
+export type QueryAuditTrailsArgs = {
+    first?: Maybe<Scalars['Int']>
+    last?: Maybe<Scalars['Int']>
+    before?: Maybe<Scalars['String']>
+    after?: Maybe<Scalars['String']>
+    order?: Maybe<AuditTrailFilter_Order>
+    request?: Maybe<Scalars['String']>
+    request_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    user?: Maybe<Scalars['String']>
+    user_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    subject?: Maybe<Scalars['String']>
+    subject_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    resource?: Maybe<Scalars['String']>
+    resource_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    resourceType?: Maybe<Scalars['String']>
+    endpoint?: Maybe<Scalars['String']>
+    endpoint_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    contentType?: Maybe<Scalars['String']>
+    contentType_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    content?: Maybe<Scalars['String']>
+    content_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    session?: Maybe<Scalars['String']>
+    session_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    dateCreated?: Maybe<AuditTrailFilter_DateCreated>
+    dateModified?: Maybe<AuditTrailFilter_DateModified>
+}
+
+export type QueryChangeLogArgs = {
+    id: Scalars['ID']
+}
+
+export type QueryChangeLogsArgs = {
+    first?: Maybe<Scalars['Int']>
+    last?: Maybe<Scalars['Int']>
+    before?: Maybe<Scalars['String']>
+    after?: Maybe<Scalars['String']>
+    order?: Maybe<ChangeLogFilter_Order>
+    action?: Maybe<Scalars['String']>
+    action_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    objectId?: Maybe<Scalars['String']>
+    objectId_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    objectClass?: Maybe<Scalars['String']>
+    objectClass_list?: Maybe<Array<Maybe<Scalars['String']>>>
+    version?: Maybe<Scalars['Int']>
+    version_list?: Maybe<Array<Maybe<Scalars['Int']>>>
+    dateCreated?: Maybe<ChangeLogFilter_DateCreated>
+    dateModified?: Maybe<ChangeLogFilter_DateModified>
+}
+
+/** A node, according to the Relay specification. */
+export type Node = {
+    /** The id of this node. */
+    id: Scalars['ID']
+}
+
+export type Memo = Node & {
+    __typename?: 'Memo'
+    id: Scalars['ID']
+    /** A contact component person */
+    author: Scalars['String']
+    /** Name of the memo */
+    name: Scalars['String']
+    /** Topic of the memo */
+    topic: Scalars['String']
+    /** Description of the memo */
+    description: Scalars['String']
+    /** The moment this resource was created */
+    dateCreated?: Maybe<Scalars['String']>
+    /** The moment this resource last Modified */
+    dateModified?: Maybe<Scalars['String']>
+}
+
+export type MemoFilter_Order = {
+    id?: Maybe<Scalars['String']>
+    author?: Maybe<Scalars['String']>
+    name?: Maybe<Scalars['String']>
+    topic?: Maybe<Scalars['String']>
+    description?: Maybe<Scalars['String']>
+    dateCreated?: Maybe<Scalars['String']>
+    dateModified?: Maybe<Scalars['String']>
+}
+
+/** Connection for Memo. */
+export type MemoConnection = {
+    __typename?: 'MemoConnection'
+    edges?: Maybe<Array<Maybe<MemoEdge>>>
+    pageInfo: MemoPageInfo
+    totalCount: Scalars['Int']
+}
+
+/** Edge of Memo. */
+export type MemoEdge = {
+    __typename?: 'MemoEdge'
+    node?: Maybe<Memo>
+    cursor: Scalars['String']
+}
+
+/** Information about the current page. */
+export type MemoPageInfo = {
+    __typename?: 'MemoPageInfo'
+    endCursor?: Maybe<Scalars['String']>
+    startCursor?: Maybe<Scalars['String']>
+    hasNextPage: Scalars['Boolean']
+    hasPreviousPage: Scalars['Boolean']
+}
+
+/** An resource representing a log line. */
+export type AuditTrail = Node & {
+    __typename?: 'AuditTrail'
+    id: Scalars['ID']
+    /** The id of the request within that application */
+    request?: Maybe<Scalars['String']>
+    /** The user on behalf of wich the request was made */
+    user?: Maybe<Scalars['String']>
+    /** ??? */
+    subject?: Maybe<Scalars['String']>
+    /** The procces on behalf of wich the request was made */
+    process?: Maybe<Scalars['String']>
+    /** The moment this request was created */
+    dataElements?: Maybe<Scalars['Iterable']>
+    /** The moment this request was created */
+    dataSubjects?: Maybe<Scalars['Iterable']>
+    /** The resource that was requested */
+    resource?: Maybe<Scalars['String']>
+    /** The type of the resource that was requested */
+    resourceType?: Maybe<Scalars['String']>
+    /** The moment this request was created */
+    route?: Maybe<Scalars['String']>
+    /** The endpoint that the request was made to */
+    endpoint?: Maybe<Scalars['String']>
+    /** The method that was used */
+    method?: Maybe<Scalars['String']>
+    /** The contentType that was reqousted */
+    accept?: Maybe<Scalars['String']>
+    /** The contentType that was suplieds */
+    contentType?: Maybe<Scalars['String']>
+    /** The moment this request was created */
+    content?: Maybe<Scalars['String']>
+    /** The moment this request was created */
+    ip?: Maybe<Scalars['String']>
+    /** The moment this request was created */
+    session: Scalars['String']
+    /** The headers supplied by client */
+    headers: Scalars['Iterable']
+    /** The status code returned to client */
+    statusCode?: Maybe<Scalars['Int']>
+    /** Whether or not the reqousted endpoint was found */
+    notFound?: Maybe<Scalars['Boolean']>
+    /** Whether or not the client was allowed to the reqousted endpoint */
+    forbidden?: Maybe<Scalars['Boolean']>
+    /** Whether or not there where any problems */
+    ok?: Maybe<Scalars['Boolean']>
+    /** The moment this request was created */
+    dateCreated?: Maybe<Scalars['String']>
+    /** The moment this request last Modified */
+    dateModified?: Maybe<Scalars['String']>
+}
+
+export type AuditTrailFilter_Order = {
+    application?: Maybe<Scalars['String']>
+    request?: Maybe<Scalars['String']>
+    user?: Maybe<Scalars['String']>
+    subject?: Maybe<Scalars['String']>
+    resource?: Maybe<Scalars['String']>
+    resourceType?: Maybe<Scalars['String']>
+    endpoint?: Maybe<Scalars['String']>
+    contentType?: Maybe<Scalars['String']>
+    content?: Maybe<Scalars['String']>
+    session?: Maybe<Scalars['String']>
+    dateCreated?: Maybe<Scalars['String']>
+    dateModified?: Maybe<Scalars['String']>
+}
+
+export type AuditTrailFilter_DateCreated = {
+    before?: Maybe<Scalars['String']>
+    strictly_before?: Maybe<Scalars['String']>
+    after?: Maybe<Scalars['String']>
+    strictly_after?: Maybe<Scalars['String']>
+}
+
+export type AuditTrailFilter_DateModified = {
+    before?: Maybe<Scalars['String']>
+    strictly_before?: Maybe<Scalars['String']>
+    after?: Maybe<Scalars['String']>
+    strictly_after?: Maybe<Scalars['String']>
+}
+
+/** Connection for AuditTrail. */
+export type AuditTrailConnection = {
+    __typename?: 'AuditTrailConnection'
+    edges?: Maybe<Array<Maybe<AuditTrailEdge>>>
+    pageInfo: AuditTrailPageInfo
+    totalCount: Scalars['Int']
+}
+
+/** Edge of AuditTrail. */
+export type AuditTrailEdge = {
+    __typename?: 'AuditTrailEdge'
+    node?: Maybe<AuditTrail>
+    cursor: Scalars['String']
+}
+
+/** Information about the current page. */
+export type AuditTrailPageInfo = {
+    __typename?: 'AuditTrailPageInfo'
+    endCursor?: Maybe<Scalars['String']>
+    startCursor?: Maybe<Scalars['String']>
+    hasNextPage: Scalars['Boolean']
+    hasPreviousPage: Scalars['Boolean']
+}
+
+/** An resource representing a log line. */
+export type ChangeLog = Node & {
+    __typename?: 'ChangeLog'
+    id: Scalars['ID']
+    /** The moment this request was created */
+    session?: Maybe<Scalars['String']>
+    /** The moment this request was created */
+    dateCreated?: Maybe<Scalars['String']>
+    /** The moment this request last Modified */
+    dateModified?: Maybe<Scalars['String']>
+    action: Scalars['String']
+    objectClass: Scalars['String']
+    objectId?: Maybe<Scalars['String']>
+    username?: Maybe<Scalars['String']>
+    data?: Maybe<Scalars['Iterable']>
+    version: Scalars['Int']
+}
+
+export type ChangeLogFilter_Order = {
+    action?: Maybe<Scalars['String']>
+    objectId?: Maybe<Scalars['String']>
+    objectClass?: Maybe<Scalars['String']>
+    version?: Maybe<Scalars['String']>
+    username?: Maybe<Scalars['String']>
+    dateCreated?: Maybe<Scalars['String']>
+    dateModified?: Maybe<Scalars['String']>
+}
+
+export type ChangeLogFilter_DateCreated = {
+    before?: Maybe<Scalars['String']>
+    strictly_before?: Maybe<Scalars['String']>
+    after?: Maybe<Scalars['String']>
+    strictly_after?: Maybe<Scalars['String']>
+}
+
+export type ChangeLogFilter_DateModified = {
+    before?: Maybe<Scalars['String']>
+    strictly_before?: Maybe<Scalars['String']>
+    after?: Maybe<Scalars['String']>
+    strictly_after?: Maybe<Scalars['String']>
+}
+
+/** Connection for ChangeLog. */
+export type ChangeLogConnection = {
+    __typename?: 'ChangeLogConnection'
+    edges?: Maybe<Array<Maybe<ChangeLogEdge>>>
+    pageInfo: ChangeLogPageInfo
+    totalCount: Scalars['Int']
+}
+
+/** Edge of ChangeLog. */
+export type ChangeLogEdge = {
+    __typename?: 'ChangeLogEdge'
+    node?: Maybe<ChangeLog>
+    cursor: Scalars['String']
+}
+
+/** Information about the current page. */
+export type ChangeLogPageInfo = {
+    __typename?: 'ChangeLogPageInfo'
+    endCursor?: Maybe<Scalars['String']>
+    startCursor?: Maybe<Scalars['String']>
+    hasNextPage: Scalars['Boolean']
+    hasPreviousPage: Scalars['Boolean']
+}
+
+export type Mutation = {
+    __typename?: 'Mutation'
+    /** Deletes a Memo. */
+    deleteMemo?: Maybe<DeleteMemoPayload>
+    /** Updates a Memo. */
+    updateMemo?: Maybe<UpdateMemoPayload>
+    /** Creates a Memo. */
+    createMemo?: Maybe<CreateMemoPayload>
+    /** Deletes a AuditTrail. */
+    deleteAuditTrail?: Maybe<DeleteAuditTrailPayload>
+    /** Updates a AuditTrail. */
+    updateAuditTrail?: Maybe<UpdateAuditTrailPayload>
+    /** Creates a AuditTrail. */
+    createAuditTrail?: Maybe<CreateAuditTrailPayload>
+    /** Deletes a ChangeLog. */
+    deleteChangeLog?: Maybe<DeleteChangeLogPayload>
+    /** Updates a ChangeLog. */
+    updateChangeLog?: Maybe<UpdateChangeLogPayload>
+    /** Creates a ChangeLog. */
+    createChangeLog?: Maybe<CreateChangeLogPayload>
+}
+
+export type MutationDeleteMemoArgs = {
+    input: DeleteMemoInput
+}
+
+export type MutationUpdateMemoArgs = {
+    input: UpdateMemoInput
+}
+
+export type MutationCreateMemoArgs = {
+    input: CreateMemoInput
+}
+
+export type MutationDeleteAuditTrailArgs = {
+    input: DeleteAuditTrailInput
+}
+
+export type MutationUpdateAuditTrailArgs = {
+    input: UpdateAuditTrailInput
+}
+
+export type MutationCreateAuditTrailArgs = {
+    input: CreateAuditTrailInput
+}
+
+export type MutationDeleteChangeLogArgs = {
+    input: DeleteChangeLogInput
+}
+
+export type MutationUpdateChangeLogArgs = {
+    input: UpdateChangeLogInput
+}
+
+export type MutationCreateChangeLogArgs = {
+    input: CreateChangeLogInput
+}
+
+export type DeleteMemoInput = {
+    id: Scalars['ID']
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+export type DeleteMemoPayload = {
+    __typename?: 'deleteMemoPayload'
+    memo?: Maybe<Memo>
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+export type UpdateMemoInput = {
+    id: Scalars['ID']
+    /** A contact component person */
+    author?: Maybe<Scalars['String']>
+    /** Name of the memo */
+    name?: Maybe<Scalars['String']>
+    /** Topic of the memo */
+    topic?: Maybe<Scalars['String']>
+    /** Description of the memo */
+    description?: Maybe<Scalars['String']>
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+export type UpdateMemoPayload = {
+    __typename?: 'updateMemoPayload'
+    memo?: Maybe<Memo>
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+export type CreateMemoInput = {
+    /** A contact component person */
+    author: Scalars['String']
+    /** Name of the memo */
+    name: Scalars['String']
+    /** Topic of the memo */
+    topic: Scalars['String']
+    /** Description of the memo */
+    description: Scalars['String']
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+export type CreateMemoPayload = {
+    __typename?: 'createMemoPayload'
+    memo?: Maybe<Memo>
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type DeleteAuditTrailInput = {
+    id: Scalars['ID']
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type DeleteAuditTrailPayload = {
+    __typename?: 'deleteAuditTrailPayload'
+    auditTrail?: Maybe<AuditTrail>
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type UpdateAuditTrailInput = {
+    id: Scalars['ID']
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type UpdateAuditTrailPayload = {
+    __typename?: 'updateAuditTrailPayload'
+    auditTrail?: Maybe<AuditTrail>
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type CreateAuditTrailInput = {
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type CreateAuditTrailPayload = {
+    __typename?: 'createAuditTrailPayload'
+    auditTrail?: Maybe<AuditTrail>
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type DeleteChangeLogInput = {
+    id: Scalars['ID']
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type DeleteChangeLogPayload = {
+    __typename?: 'deleteChangeLogPayload'
+    changeLog?: Maybe<ChangeLog>
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type UpdateChangeLogInput = {
+    id: Scalars['ID']
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type UpdateChangeLogPayload = {
+    __typename?: 'updateChangeLogPayload'
+    changeLog?: Maybe<ChangeLog>
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type CreateChangeLogInput = {
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+/** An resource representing a log line. */
+export type CreateChangeLogPayload = {
+    __typename?: 'createChangeLogPayload'
+    changeLog?: Maybe<ChangeLog>
+    clientMutationId?: Maybe<Scalars['String']>
+}
+
+export type CreateMemoMutationVariables = Exact<{
+    input: CreateMemoInput
+}>
+
+export type CreateMemoMutation = { __typename?: 'Mutation' } & {
+    createMemo?: Maybe<
+        { __typename?: 'createMemoPayload' } & {
+            memo?: Maybe<{ __typename?: 'Memo' } & Pick<Memo, 'id' | 'name' | 'description' | 'author' | 'topic'>>
+        }
+    >
+}
+
+export type FindMemosByTopicAndAuthorQueryVariables = Exact<{
+    topic: Scalars['String']
+    author: Scalars['String']
+}>
+
+export type FindMemosByTopicAndAuthorQuery = { __typename?: 'Query' } & {
+    memos?: Maybe<
+        { __typename?: 'MemoConnection' } & {
+            edges?: Maybe<
+                Array<
+                    Maybe<
+                        { __typename?: 'MemoEdge' } & {
+                            node?: Maybe<
+                                { __typename?: 'Memo' } & Pick<Memo, 'id' | 'name' | 'description' | 'author' | 'topic'>
+                            >
+                        }
+                    >
+                >
+            >
+        }
+    >
+}
+
+export const CreateMemoDocument = gql`
+    mutation createMemo($input: createMemoInput!) {
+        createMemo(input: $input) {
+            memo {
+                id
+                name
+                description
+                author
+                topic
+            }
+        }
+    }
+`
+export const FindMemosByTopicAndAuthorDocument = gql`
+    query findMemosByTopicAndAuthor($topic: String!, $author: String!) {
+        memos(topic: $topic, author: $author) {
+            edges {
+                node {
+                    id
+                    name
+                    description
+                    author
+                    topic
+                }
+            }
+        }
+    }
+`
+
+export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>
+
+const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction()
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
+    return {
+        createMemo(
+            variables: CreateMemoMutationVariables,
+            requestHeaders?: Dom.RequestInit['headers']
+        ): Promise<CreateMemoMutation> {
+            return withWrapper(() =>
+                client.request<CreateMemoMutation>(print(CreateMemoDocument), variables, requestHeaders)
+            )
+        },
+        findMemosByTopicAndAuthor(
+            variables: FindMemosByTopicAndAuthorQueryVariables,
+            requestHeaders?: Dom.RequestInit['headers']
+        ): Promise<FindMemosByTopicAndAuthorQuery> {
+            return withWrapper(() =>
+                client.request<FindMemosByTopicAndAuthorQuery>(
+                    print(FindMemosByTopicAndAuthorDocument),
+                    variables,
+                    requestHeaders
+                )
+            )
+        },
+    }
+}
+export type Sdk = ReturnType<typeof getSdk>

--- a/server/src/generated/memo-introspection-result.json
+++ b/server/src/generated/memo-introspection-result.json
@@ -1,0 +1,5 @@
+{
+    "possibleTypes": {
+        "Node": ["Memo", "AuditTrail", "ChangeLog"]
+    }
+}

--- a/server/src/queries/memo/createMemo.graphql
+++ b/server/src/queries/memo/createMemo.graphql
@@ -1,0 +1,11 @@
+mutation createMemo($input: createMemoInput!) {
+    createMemo(input: $input) {
+        memo {
+            id
+            name
+            description
+            author
+            topic
+        }
+    }
+}

--- a/server/src/queries/memo/findMemosByTopicAndAuthor.graphql
+++ b/server/src/queries/memo/findMemosByTopicAndAuthor.graphql
@@ -1,0 +1,13 @@
+query findMemosByTopicAndAuthor($topic: String!, $author: String!) {
+    memos(topic: $topic, author: $author) {
+        edges {
+            node {
+                id
+                name
+                description
+                author
+                topic
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR will add integration with Memo API. The queries `findMemosByTopicAndAuthor` and `createMemo` will be used by our mutation for the public registration form. I created this separate PR for the Memo API integration to be able to merge it before the registration form mutation is done. Also, it's nice to keep PRs small.