### PR TITLE
Feature/aanbieder participant registration view boilerplate

### DIFF
--- a/client/src/components/Domain/Aanbieder/AanbiederParticipantRegistrationFields.tsx
+++ b/client/src/components/Domain/Aanbieder/AanbiederParticipantRegistrationFields.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { AanbiederParticipantDetail } from 'views/Authorized/Supplier/AanbiederView/mocks'
+
+interface Props {
+    participant: AanbiederParticipantDetail
+}
+
+// TODO
+export const AanbiederParticipantRegistrationFields: React.FunctionComponent<Props> = props => {
+    return null
+}

--- a/client/src/routes/supplier/supplierRoutes.ts
+++ b/client/src/routes/supplier/supplierRoutes.ts
@@ -49,6 +49,7 @@ export const supplierRoutes = {
             referred: '/supplier/participants/referred',
         },
         detail: {
+            index: '/supplier/participant',
             overview: '/supplier/participant/overview',
             registration: '/supplier/participant/registration',
             folder: '/supplier/participant/folder',

--- a/client/src/views/Authorized/Supplier/AanbiederView/AanbiederParticipantView/AanbiederParticipantRegistrationView.tsx
+++ b/client/src/views/Authorized/Supplier/AanbiederView/AanbiederParticipantView/AanbiederParticipantRegistrationView.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { useLingui } from '@lingui/react'
+
+import Headline, { SpacingType } from 'components/Chrome/Headline'
+import Column from 'components/Core/Layout/Column/Column'
+import { AanbiederParticipantTab, AanbiederParticipantTabs } from 'components/Domain/Aanbieder/AanbiederParticipantTab'
+import { useMockQuery } from 'components/hooks/useMockQuery'
+import { AanbiederParticipantDetail, aanbiederParticipantDetail } from '../mocks'
+import Center from 'components/Core/Layout/Center/Center'
+import Spinner, { Animation } from 'components/Core/Feedback/Spinner/Spinner'
+import ErrorBlock from 'components/Core/Feedback/Error/ErrorBlock'
+import { t } from '@lingui/macro'
+import { AanbiederParticipantRegistrationFields } from 'components/Domain/Aanbieder/AanbiederParticipantRegistrationFields'
+
+interface Props {
+    participantId: number
+}
+
+export const AanbiederParticipantRegistrationView: React.FunctionComponent<Props> = ({ participantId }) => {
+    const { i18n } = useLingui()
+
+    // TODO: replace with the api call/query (using participantId prop)
+    const { data, loading, error } = useMockQuery<AanbiederParticipantDetail>(aanbiederParticipantDetail)
+
+    return (
+        <>
+            {/* TODO: add breadcrumb */}
+            <Headline spacingType={SpacingType.small} title={data?.fullName || ''} />
+            <Column spacing={10}>
+                <AanbiederParticipantTabs currentTab={AanbiederParticipantTab.registration} />
+                {renderList()}
+            </Column>
+        </>
+    )
+
+    // TODO
+    function renderList() {
+        if (loading) {
+            return (
+                <Center grow={true}>
+                    <Spinner type={Animation.pageSpinner} />
+                </Center>
+            )
+        }
+
+        if (error || !data) {
+            return (
+                <ErrorBlock
+                    title={i18n._(t`Er ging iets fout`)}
+                    message={i18n._(t`Wij konden de gegevens niet ophalen, probeer het opnieuw`)}
+                />
+            )
+        }
+
+        return <AanbiederParticipantRegistrationFields participant={data} />
+    }
+}

--- a/client/src/views/Authorized/Supplier/AanbiederView/AanbiederParticipantView/AanbiederParticipantView.tsx
+++ b/client/src/views/Authorized/Supplier/AanbiederView/AanbiederParticipantView/AanbiederParticipantView.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Route, Switch, useLocation } from 'react-router'
 import { routes } from 'routes/routes'
 import { AanbiederParticipantOverviewView } from './AanbiederParticipantOverviewView'
+import { AanbiederParticipantRegistrationView } from './AanbiederParticipantRegistrationView'
 
 interface LocationStateProps {
     participantId: number
@@ -16,6 +17,7 @@ export const AanbiederParticipantView: React.FunctionComponent = () => {
     return (
         <Switch>
             <Route path={basePath.overview} render={() => <AanbiederParticipantOverviewView {...props} />} />
+            <Route path={basePath.registration} render={() => <AanbiederParticipantRegistrationView {...props} />} />
         </Switch>
     )
 }

--- a/client/src/views/Authorized/Supplier/AanbiederView/AanbiederView.tsx
+++ b/client/src/views/Authorized/Supplier/AanbiederView/AanbiederView.tsx
@@ -16,7 +16,7 @@ export const AanbiederView: React.FunctionComponent = () => {
             <Route path={participantRoute.overview.active} component={AanbiederActiveParticipantsOverviewView} />
             <Route path={participantRoute.overview.completed} component={AanbiederCompletedParticipantsOverviewView} />
             <Route path={participantRoute.overview.referred} component={AanbiederReferredParticipantsOverviewView} />
-            <Route path={participantRoute.detail.overview} component={AanbiederParticipantView} />
+            <Route path={participantRoute.detail.index} component={AanbiederParticipantView} />
         </Switch>
     )
 }


### PR DESCRIPTION
This PR will add the boilerplate for the aanbieder participant registration tab view. Note that this code has unhandled todos as its not needed within the current sprint.