### PR TITLE
Feature/BISC-79 add updateStudent mutation stub

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -459,7 +459,7 @@ export type CreateStudentInputType = {
     givenName: Scalars['String']
     additionalName?: Maybe<Scalars['String']>
     familyName: Scalars['String']
-    email: Scalars['String']
+    email?: Maybe<Scalars['String']>
     telephone?: Maybe<Scalars['String']>
 }
 
@@ -468,7 +468,7 @@ export type UpdateStudentInputType = {
     givenName: Scalars['String']
     additionalName?: Maybe<Scalars['String']>
     familyName: Scalars['String']
-    email: Scalars['String']
+    email?: Maybe<Scalars['String']>
     telephone?: Maybe<Scalars['String']>
 }
 

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -272,6 +272,7 @@ export type Mutation = {
     deleteRegistration: Scalars['Boolean']
     acceptRegistration: StudentType
     createStudent: StudentType
+    updateStudent: StudentType
 }
 
 export type MutationAddPersonArgs = {
@@ -377,6 +378,10 @@ export type MutationCreateStudentArgs = {
     input: CreateStudentInputType
 }
 
+export type MutationUpdateStudentArgs = {
+    input: UpdateStudentInputType
+}
+
 export type CreateTaalhuisAddressInputType = {
     street: Scalars['String']
     houseNumber: Scalars['String']
@@ -451,6 +456,15 @@ export type UpdateAanbiederEmployeeInputType = {
 
 export type CreateStudentInputType = {
     taalhuisId: Scalars['String']
+    givenName: Scalars['String']
+    additionalName?: Maybe<Scalars['String']>
+    familyName: Scalars['String']
+    email: Scalars['String']
+    telephone: Scalars['String']
+}
+
+export type UpdateStudentInputType = {
+    studentId: Scalars['String']
     givenName: Scalars['String']
     additionalName?: Maybe<Scalars['String']>
     familyName: Scalars['String']

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -460,7 +460,7 @@ export type CreateStudentInputType = {
     additionalName?: Maybe<Scalars['String']>
     familyName: Scalars['String']
     email: Scalars['String']
-    telephone: Scalars['String']
+    telephone?: Maybe<Scalars['String']>
 }
 
 export type UpdateStudentInputType = {
@@ -469,7 +469,7 @@ export type UpdateStudentInputType = {
     additionalName?: Maybe<Scalars['String']>
     familyName: Scalars['String']
     email: Scalars['String']
-    telephone: Scalars['String']
+    telephone?: Maybe<Scalars['String']>
 }
 
 export type AddPersonMutationVariables = Exact<{

--- a/server/src/Aanbieder/AanbiederEmployeeService.ts
+++ b/server/src/Aanbieder/AanbiederEmployeeService.ts
@@ -42,6 +42,7 @@ export class AanbiederEmployeeService {
                 const user = await this.userRepository.findByPersonId(employee.person)
 
                 assertNotNil(person, `Person not found for employee ${employee.id}`)
+                assertNotNil(person.email, `Person ${person.id} does not have an email address sest, but it should`)
                 assertNotNil(user, `User not found for person ${employee.person}`)
 
                 const aanbieder = await this.findAanbieder(employee)
@@ -87,6 +88,7 @@ export class AanbiederEmployeeService {
         const user = await this.userRepository.findByPersonId(employee.person)
 
         assertNotNil(person, `Person not found for employee ${employee.id}`)
+        assertNotNil(person.email, `Person ${person.id} does not have an email address sest, but it should`)
         assertNotNil(user, `User not found for person ${employee.person}`)
 
         const aanbieder = await this.findAanbieder(employee)

--- a/server/src/Aanbieder/DeleteAanbiederEmployeeService.ts
+++ b/server/src/Aanbieder/DeleteAanbiederEmployeeService.ts
@@ -31,7 +31,9 @@ export class DeleteAanbiederEmployeeService {
         assertNotNil(employee, `Employee with id ${person.id} not found`)
 
         // delete cc
-        await this.emailRepository.deleteEmail(person.emailId)
+        if (person.emailId) {
+            await this.emailRepository.deleteEmail(person.emailId)
+        }
 
         if (person.telephoneId) {
             await this.telephoneRepository.deleteTelephone(person.telephoneId)

--- a/server/src/Aanbieder/UpdateAanbiederEmployeeService.ts
+++ b/server/src/Aanbieder/UpdateAanbiederEmployeeService.ts
@@ -65,12 +65,11 @@ export class UpdateAanbiederEmployeeService {
 
         const employee = await this.employeeRepository.findByPersonId(personId)
         assertNotNil(employee, `Employee not found for Person ${personId}`)
-
         assertNotNil(employee.person)
+
         const person = await this.personRepository.findById(employee.person)
-        if (!person) {
-            throw new Error(`Person with id ${employee.person} does not exist.`)
-        }
+        assertNotNil(person, `Person ${employee.person} not found for employee ${employee.id}`)
+        assertNotNil(person.emailId, `Person ${person.id} does not have an emailId set, but it should`)
 
         assertNotNil(employee.organization)
         const aanbieder = await this.organizationRepository.getOne(employee.organization)

--- a/server/src/CommonGroundAPI/cc/PersonRepository.ts
+++ b/server/src/CommonGroundAPI/cc/PersonRepository.ts
@@ -17,7 +17,7 @@ interface UpdatePersonInputType {
     additionalName?: string
     familyName: string
     telephoneId?: string
-    emailId: string
+    emailId?: string
 }
 
 type PersonEntity = {
@@ -27,8 +27,8 @@ type PersonEntity = {
     familyName: string
     telephone?: string
     telephoneId?: string
-    email: string
-    emailId: string
+    email?: string
+    emailId?: string
     addressIds: string[]
 }
 
@@ -68,7 +68,7 @@ export class PersonRepository extends CCRepository {
                 additionalName: input.additionalName,
                 familyName: input.familyName,
                 telephones: input.telephoneId ? [this.stripURLfromID(input.telephoneId)] : [],
-                emails: [this.stripURLfromID(input.emailId)],
+                emails: input.emailId ? [this.stripURLfromID(input.emailId)] : [],
             },
         })
         const person = result.updatePerson?.person
@@ -115,11 +115,11 @@ export class PersonRepository extends CCRepository {
             : []
         const addressIds = addressNodes.map(addressNode => addressNode.id)
 
+        // Telephone is not a required field, so we dont have assertNotNil() here
         const emailNode = person.emails?.edges?.pop()?.node
-        assertNotNil(emailNode)
 
-        const email = emailNode.email
-        const emailId = this.makeURLfromID(emailNode.id)
+        const email = emailNode ? emailNode.email : undefined
+        const emailId = emailNode ? this.makeURLfromID(emailNode.id) : undefined
 
         const personEntity: PersonEntity = {
             id: this.makeURLfromID(person.id),

--- a/server/src/Student/StudentResolver.ts
+++ b/server/src/Student/StudentResolver.ts
@@ -11,6 +11,7 @@ import { StudentPolicyService } from './services/StudentPolicyService'
 import { StudentService } from './services/StudentService'
 import { CreateStudentInputType } from './types/CreateStudentInputType'
 import { StudentType } from './types/StudentType'
+import { UpdateStudentInputType } from './types/UpdateStudentInputType'
 
 registerEnumType(ParticipantStatusEnum, { name: 'ParticipantStatusEnum' })
 
@@ -91,6 +92,23 @@ export class StudentResolver {
         }
 
         return this.createStudentService.createStudent(input)
+    }
+
+    @Mutation(() => StudentType)
+    public async updateStudent(
+        @CurrentUser() contextUser: ContextUser,
+        @Args('input') input: UpdateStudentInputType
+    ): Promise<StudentType> {
+        const student = await this.studentService.findByStudentId(input.studentId)
+
+        // TODO: canUpdate policy
+        const isAuthorized = this.studentPolicyService.canCreateForTaalhuis(contextUser, student.taalhuis.id)
+        if (isAuthorized !== true) {
+            throw new UnauthorizedException()
+        }
+
+        // TODO: Add updateStudent implementation
+        return student
     }
 
     @Query(() => [StudentType])

--- a/server/src/Student/services/CreateStudentService.ts
+++ b/server/src/Student/services/CreateStudentService.ts
@@ -29,13 +29,14 @@ export interface CreateStudentInput {
     // civicIntegrationRequirementFinishDate?: Date
 
     givenName: string
-    additionalName?: string
+    additionalName?: string | null
     familyName: string
 
     // gender: StudentGenderEnum
 
-    email?: string
-    telephone?: string
+    // TODO: Make this nullable
+    email: string
+    telephone?: string | null
 }
 
 @Injectable()
@@ -69,7 +70,7 @@ export class CreateStudentService {
         // cc/person
         const person = await this.personRepository.createPerson({
             givenName: input.givenName,
-            additionalName: input.additionalName,
+            additionalName: input.additionalName ?? undefined,
             familyName: input.familyName,
             telephoneId: telephone ? telephone.id : undefined,
             emailId: email ? email.id : undefined,

--- a/server/src/Student/services/CreateStudentService.ts
+++ b/server/src/Student/services/CreateStudentService.ts
@@ -34,8 +34,7 @@ export interface CreateStudentInput {
 
     // gender: StudentGenderEnum
 
-    // TODO: Make this nullable
-    email: string
+    email?: string | null
     telephone?: string | null
 }
 

--- a/server/src/Student/services/RegistrationService.ts
+++ b/server/src/Student/services/RegistrationService.ts
@@ -34,7 +34,9 @@ export class RegistrationService {
             await this.addressRepository.deleteAddress(addressId)
         }
 
-        await this.emailRepository.deleteEmail(person.emailId)
+        if (person.emailId) {
+            await this.emailRepository.deleteEmail(person.emailId)
+        }
 
         if (person.telephoneId) {
             await this.telephoneRepository.deleteTelephone(person.telephoneId)

--- a/server/src/Student/services/StudentService.ts
+++ b/server/src/Student/services/StudentService.ts
@@ -128,6 +128,7 @@ export class StudentService {
         const person = await this.personRepository.findById(personId)
         assertNotNil(person, `Person ${personId} not found for Registrar Org ${organizationId}`)
         assertNotNil(person.telephone)
+        assertNotNil(person.email)
 
         return {
             id: organization.id,

--- a/server/src/Student/types/CreateStudentInputType.ts
+++ b/server/src/Student/types/CreateStudentInputType.ts
@@ -25,8 +25,8 @@ export class CreateStudentInputType implements CreateStudentInput {
     @Field()
     public givenName!: string
 
-    @Field({ nullable: true })
-    public additionalName?: string
+    @Field(() => String, { nullable: true })
+    public additionalName?: string | null
 
     @Field()
     public familyName!: string
@@ -35,9 +35,10 @@ export class CreateStudentInputType implements CreateStudentInput {
     // @IsIn(Object.values(StudentGenderEnum))
     // public gender!: StudentGenderEnum
 
-    @Field()
+    // TODO: Make this nullable
+    @Field(() => String)
     public email!: string
 
-    @Field()
-    public telephone!: string
+    @Field(() => String, { nullable: true })
+    public telephone?: string | null
 }

--- a/server/src/Student/types/CreateStudentInputType.ts
+++ b/server/src/Student/types/CreateStudentInputType.ts
@@ -35,9 +35,8 @@ export class CreateStudentInputType implements CreateStudentInput {
     // @IsIn(Object.values(StudentGenderEnum))
     // public gender!: StudentGenderEnum
 
-    // TODO: Make this nullable
-    @Field(() => String)
-    public email!: string
+    @Field(() => String, { nullable: true })
+    public email?: string | null
 
     @Field(() => String, { nullable: true })
     public telephone?: string | null

--- a/server/src/Student/types/UpdateStudentInputType.ts
+++ b/server/src/Student/types/UpdateStudentInputType.ts
@@ -11,15 +11,16 @@ export class UpdateStudentInputType {
     @Field()
     public givenName!: string
 
-    @Field({ nullable: true })
-    public additionalName?: string
+    @Field(() => String, { nullable: true })
+    public additionalName?: string | null
 
     @Field()
     public familyName!: string
 
-    @Field()
+    // TODO: Make this nullable
+    @Field(() => String)
     public email!: string
 
-    @Field()
-    public telephone!: string
+    @Field(() => String, { nullable: true })
+    public telephone?: string | null
 }

--- a/server/src/Student/types/UpdateStudentInputType.ts
+++ b/server/src/Student/types/UpdateStudentInputType.ts
@@ -1,0 +1,25 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsUrl } from 'class-validator'
+
+// TODO: Should implement UpdateStudentInput
+@InputType()
+export class UpdateStudentInputType {
+    @Field()
+    @IsUrl()
+    public studentId!: string
+
+    @Field()
+    public givenName!: string
+
+    @Field({ nullable: true })
+    public additionalName?: string
+
+    @Field()
+    public familyName!: string
+
+    @Field()
+    public email!: string
+
+    @Field()
+    public telephone!: string
+}

--- a/server/src/Student/types/UpdateStudentInputType.ts
+++ b/server/src/Student/types/UpdateStudentInputType.ts
@@ -17,9 +17,8 @@ export class UpdateStudentInputType {
     @Field()
     public familyName!: string
 
-    // TODO: Make this nullable
-    @Field(() => String)
-    public email!: string
+    @Field(() => String, { nullable: true })
+    public email?: string | null
 
     @Field(() => String, { nullable: true })
     public telephone?: string | null

--- a/server/src/Taalhuis/DeleteTaalhuisEmployeeService.ts
+++ b/server/src/Taalhuis/DeleteTaalhuisEmployeeService.ts
@@ -31,7 +31,9 @@ export class DeleteTaalhuisEmployeeService {
         assertNotNil(employee, `Employee with id ${person.id} not found`)
 
         // delete cc
-        await this.emailRepository.deleteEmail(person.emailId)
+        if (person.emailId) {
+            await this.emailRepository.deleteEmail(person.emailId)
+        }
 
         if (person.telephoneId) {
             await this.telephoneRepository.deleteTelephone(person.telephoneId)

--- a/server/src/Taalhuis/TaalhuisEmployeeService.ts
+++ b/server/src/Taalhuis/TaalhuisEmployeeService.ts
@@ -24,6 +24,7 @@ export class TaalhuisEmployeeService {
                 const user = await this.userRepository.findByPersonId(employee.person)
 
                 assertNotNil(person, `Person not found for employee ${employee.id}`)
+                assertNotNil(person.email, `Person ${person.id} does not have an email address sest, but it should`)
                 assertNotNil(user, `User not found for person ${employee.person}`)
 
                 return {
@@ -66,6 +67,7 @@ export class TaalhuisEmployeeService {
         const user = await this.userRepository.findByPersonId(employee.person)
 
         assertNotNil(person, `Person not found for employee ${employee.id}`)
+        assertNotNil(person.email, `Person ${person.id} does not have an email address sest, but it should`)
         assertNotNil(user, `User not found for person ${employee.person}`)
 
         return {

--- a/server/src/Taalhuis/UpdateTaalhuisEmployeeService.ts
+++ b/server/src/Taalhuis/UpdateTaalhuisEmployeeService.ts
@@ -55,12 +55,11 @@ export class UpdateTaalhuisEmployeeService {
 
         const employee = await this.employeeRepository.findByPersonId(personId)
         assertNotNil(employee, `Employee not found for Person ${personId}`)
-
         assertNotNil(employee.person)
+
         const person = await this.personRepository.findById(employee.person)
-        if (!person) {
-            throw new Error(`Person with id ${employee.person} does not exist.`)
-        }
+        assertNotNil(person, `Person ${employee.person} not found for employee ${employee.id}`)
+        assertNotNil(person.emailId, `Person ${person.id} does not have an emailId set, but it should`)
 
         // TODO: This is duplicated in UpdateAanbiederEmployeeService
         const existingTelephone = person.telephone


### PR DESCRIPTION
This PR will add `updateStudent` mutation stub. Logic will be added later, this is just the mutation so the frontend can be implemented.

The students email field is optional, so we had to make the emailId on Person nullable, that is the biggest part of this PR. Email field should still be required for TaalhuisEmployee and AanbiederEmployee, but not for Student/participant. That is why we added `assertNotNil(person.email)` when fetching/updating TaalhuisEmployee and AanbiederEmployee.